### PR TITLE
修复header 中设置Host 不生效问题

### DIFF
--- a/server/client/http_client.go
+++ b/server/client/http_client.go
@@ -39,7 +39,10 @@ func HttpRequest(method, url string, body io.Reader, headers map[string]string, 
 
 		return
 	}
-
+	// 在req中设置Host，解决在header中设置Host不生效问题
+	if _, ok := headers["Host"]; ok {
+		req.Host = headers["Host"]
+	}
 	// 设置默认为utf-8编码
 	if _, ok := headers["Content-Type"]; !ok {
 		if headers == nil {


### PR DESCRIPTION
在使用中发现，在Header中设置Host 不能争取的在请求中设置，经过研究net/http包和相关文档发现，Host 现在不在Header 中设置，这样不能保证工具能够对所有情况进行压测，所以提交了这个pr。