### PR TITLE
针对go1.19环境，代码中有一个地方中了for循环陷阱

### DIFF
--- a/server/golink/http_link.go
+++ b/server/golink/http_link.go
@@ -46,7 +46,8 @@ func sendList(chanID uint64, requestList []*model.Request) (isSucceed bool, errC
 	contentLength int64) {
 	errCode = model.HTTPOk
 	for _, request := range requestList {
-		succeed, code, u, length := send(chanID, request)
+	    temp := request
+		succeed, code, u, length := send(chanID, temp)
 		isSucceed = succeed
 		errCode = code
 		requestTime = requestTime + u


### PR DESCRIPTION
我的电脑环境是go1.19，windows10
原先的代码会导致每次都是使用同一个request的指针地址，发多个线程如果复用了同一个request，无法保证线程相互之间的数据不会被打乱，for循环陷阱示例：https://learnku.com/articles/26861